### PR TITLE
Updates render method of all components to render an element 

### DIFF
--- a/src/components/ActivityIndicator.js
+++ b/src/components/ActivityIndicator.js
@@ -39,7 +39,7 @@ const ActivityIndicator = React.createClass({
   },
   mixins: [NativeMethodsMixin],
   render() {
-    return null;
+    return React.createElement('react-native-mock', null, this.props.children);
   },
 });
 

--- a/src/components/ActivityIndicatorIOS.js
+++ b/src/components/ActivityIndicatorIOS.js
@@ -40,7 +40,7 @@ const ActivityIndicatorIOS = React.createClass({
   mixins: [NativeMethodsMixin],
 
   render() {
-    return null;
+    return React.createElement('react-native-mock', null, this.props.children);
   },
 });
 

--- a/src/components/DrawerLayoutAndroid.js
+++ b/src/components/DrawerLayoutAndroid.js
@@ -107,7 +107,7 @@ const DrawerLayoutAndroid = React.createClass({
   },
 
   render() {
-    return null;
+    return React.createElement('react-native-mock', null, this.props.children);
   }
 
 });

--- a/src/components/Image.js
+++ b/src/components/Image.js
@@ -120,7 +120,7 @@ const Image = React.createClass({
     }
   },
   render() {
-    return null;
+    return React.createElement('react-native-mock', null, this.props.children);
   },
 });
 

--- a/src/components/ListView.js
+++ b/src/components/ListView.js
@@ -160,7 +160,7 @@ const ListView = React.createClass({
   },
 
   render() {
-    return null;
+    return React.createElement('react-native-mock', null, this.props.children);
   },
 });
 

--- a/src/components/Navigator.js
+++ b/src/components/Navigator.js
@@ -96,7 +96,7 @@ const Navigator = React.createClass({
     SceneConfigs: NavigatorSceneConfigs,
   },
   render() {
-    return null;
+    return React.createElement('react-native-mock', null, this.props.children);
   }
 });
 

--- a/src/components/ScrollView.js
+++ b/src/components/ScrollView.js
@@ -311,7 +311,7 @@ const ScrollView = React.createClass({
   },
 
   render() {
-    return null;
+    return React.createElement('react-native-mock', null, this.props.children);
   },
 });
 

--- a/src/components/StatusBar.js
+++ b/src/components/StatusBar.js
@@ -65,7 +65,7 @@ const StatusBar = React.createClass({
   },
 
   render() {
-    return null;
+    return React.createElement('react-native-mock', null, this.props.children);
   }
 });
 

--- a/src/components/Text.js
+++ b/src/components/Text.js
@@ -46,7 +46,7 @@ const Text = React.createClass({
   mixins: [NativeMethodsMixin],
 
   render() {
-    return null;
+    return React.createElement('react-native-mock', null, this.props.children);
   },
 });
 

--- a/src/components/TextInput.js
+++ b/src/components/TextInput.js
@@ -242,7 +242,7 @@ const TextInput = React.createClass({
 
   },
   render() {
-    return null;
+    return React.createElement('react-native-mock', null, this.props.children);
   },
 });
 

--- a/src/components/TouchableNativeFeedback.js
+++ b/src/components/TouchableNativeFeedback.js
@@ -15,7 +15,7 @@ const TouchableNativeFeedback = React.createClass({
     Ripple(color, borderless) {}
   },
   render() {
-    return null;
+    return React.createElement('react-native-mock', null, this.props.children);
   }
 });
 

--- a/src/components/TouchableOpacity.js
+++ b/src/components/TouchableOpacity.js
@@ -17,7 +17,7 @@ const TouchableOpacity = React.createClass({
   },
 
   render() {
-    return null;
+    return React.createElement('react-native-mock', null, this.props.children);
   },
 });
 

--- a/src/components/TouchableWithoutFeedback.js
+++ b/src/components/TouchableWithoutFeedback.js
@@ -64,7 +64,7 @@ const TouchableWithoutFeedback = React.createClass({
     hitSlop: EdgeInsetsPropType,
   },
   render() {
-    return null;
+    return React.createElement('react-native-mock', null, this.props.children);
   },
 });
 

--- a/src/components/View.js
+++ b/src/components/View.js
@@ -281,7 +281,7 @@ const View = React.createClass({
   },
 
   render() {
-    return null;
+    return React.createElement('react-native-mock', null, this.props.children);
   },
 });
 

--- a/src/components/WebView.js
+++ b/src/components/WebView.js
@@ -138,7 +138,7 @@ const WebView = React.createClass({
   },
 
   render() {
-    return null;
+    return React.createElement('react-native-mock', null, this.props.children);
   },
 });
 

--- a/src/components/createMockComponent.js
+++ b/src/components/createMockComponent.js
@@ -4,7 +4,7 @@ function createMockComponent(displayName) {
   return React.createClass({
     displayName,
     render() {
-      return null;
+      return React.createElement('react-native-mock', null, this.props.children);
     },
   });
 }


### PR DESCRIPTION
This is the whole point of our fork.  All elements will now render their children so we can use `mount` instead of `shallow` in enzyme. 