### PR TITLE
Updates Subscribable.Mixin to support unmounting

### DIFF
--- a/src/mixins/Subscribable.js
+++ b/src/mixins/Subscribable.js
@@ -1,34 +1,19 @@
 
 const SubscribableMixin = {
-
   componentWillMount() {
-    this._subscribableSubscriptions = [];
+    this._subscriptions = [];
   },
 
   componentWillUnmount() {
-    this._subscribableSubscriptions.forEach(
-      (subscription) => subscription.remove()
+    this._subscriptions.forEach(
+      (subscription) => subscription.eventEmitter.removeListener(subscription.eventType, subscription.listener)
     );
-    this._subscribableSubscriptions = null;
+    this._subscriptions = null;
   },
 
-  /**
-   * Special form of calling `addListener` that *guarantees* that a
-   * subscription *must* be tied to a component instance, and therefore will
-   * be cleaned up when the component is unmounted. It is impossible to create
-   * the subscription and pass it in - this method must be the one to create
-   * the subscription and therefore can guarantee it is retained in a way that
-   * will be cleaned up.
-   *
-   * @param {EventEmitter} eventEmitter emitter to subscribe to.
-   * @param {string} eventType Type of event to listen to.
-   * @param {function} listener Function to invoke when event occurs.
-   * @param {object} context Object to use as listener context.
-   */
   addListenerOn(eventEmitter, eventType, listener, context) {
-    this._subscribableSubscriptions.push(
-      eventEmitter.addListener(eventType, listener, context)
-    );
+    eventEmitter.addListener(eventType, listener, context);
+    this._subscriptions.push({ eventEmitter, eventType, listener });
   }
 };
 

--- a/test/mixins/Subscribable.js
+++ b/test/mixins/Subscribable.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import { expect } from 'chai';
+import Subscribable from '../../src/mixins/Subscribable.js';
+import DeviceEventEmitter from '../../src/plugins/DeviceEventEmitter.js';
+
+describe('Subscribable.Mixin', () => {
+  it('Can mount and unmount with a DeviceEventEmitter subscribed. Does not interupt existing events.', () => {
+    const SubscribableClass = React.createClass({
+      mixins: [Subscribable.Mixin],
+      render() {
+        return null;
+      },
+    });
+    const subscribableComponent = new SubscribableClass();
+    const existingEventType = 'Existing Event';
+    DeviceEventEmitter.addListener(existingEventType, () => {}, context);
+    expect(DeviceEventEmitter.listeners(existingEventType)).to.have.length(1);
+
+    subscribableComponent.componentWillMount();
+    subscribableComponent.addListenerOn(DeviceEventEmitter, 'Test Event Type', () => {});
+    subscribableComponent.componentWillUnmount();
+
+    expect(DeviceEventEmitter.listeners(existingEventType)).to.have.length(1);
+  });
+});


### PR DESCRIPTION
`Subscribable.Mixin` appears to have been built using code that was meant to support React's `EventEmitter`, but `DeviceEventEmitter` has been mocked using [node's `'events'` event emitter](https://nodejs.org/api/events.html).  The only use of `Subscribable.Mixin` is in `ScrollResponder.Mixin` which uses the mocked `DeviceEventEmitter`.

This PR updates `Subscribable.Mixin` to work with `DeviceEventEmitter`, including the previously unsupported `componentWillUnmount`.