### PR TITLE
Stops calling propsAnimated on createAnimatedComponent

### DIFF
--- a/src/api/Animated/createAnimatedComponent.js
+++ b/src/api/Animated/createAnimatedComponent.js
@@ -7,7 +7,6 @@ function createAnimatedComponent(Component) {
     render() {
       return (
         <Component
-          {...this._propsAnimated.__getValue()}
           ref={refName}
         />
       );


### PR DESCRIPTION
A known bug (issue #78) is causing issues with the new tab navigator component on the full flow tests. This PR does not fix the underlying issue but it works around it.