### PR TITLE
Fixes test failures caused by missing function

### DIFF
--- a/src/api/Animated/AnimatedImplementation.js
+++ b/src/api/Animated/AnimatedImplementation.js
@@ -377,7 +377,9 @@ class SpringAnimation extends Animation {
 
   stop() {
     this.__active = false;
-    window.cancelAnimationFrame(this._animationFrame);
+    if (global && global.cancelAnimationFrame) {
+      global.cancelAnimationFrame(this._animationFrame);
+    }
     this.__debouncedOnEnd({ finished: false });
   }
 }


### PR DESCRIPTION
When testing a component that has a call to `Animated.spring()`, tests would crash when stopping the animation. The crash happened because the function `window.cancelAnimationFrame` did not exist.

To solve this, I replaced the offending line with 3 lines that are in the other `stop()` functions for other animations. This eliminated the crash.