### PR TITLE
Updates prop types for RN 0.42.x

### DIFF
--- a/src/propTypes/ImageStylePropTypes.js
+++ b/src/propTypes/ImageStylePropTypes.js
@@ -47,6 +47,11 @@ const ImageStylePropTypes = {
    * @platform android
    */
   overlayColor: PropTypes.string,
+
+  borderTopLeftRadius: PropTypes.number,
+  borderTopRightRadius: PropTypes.number,
+  borderBottomLeftRadius: PropTypes.number,
+  borderBottomRightRadius: PropTypes.number,
 };
 
 module.exports = ImageStylePropTypes;

--- a/src/propTypes/LayoutPropTypes.js
+++ b/src/propTypes/LayoutPropTypes.js
@@ -18,26 +18,102 @@ const { PropTypes } = React;
  * algorithm and affect the positioning and sizing of views.
  */
 const LayoutPropTypes = {
-  width: PropTypes.number,
-  height: PropTypes.number,
-  top: PropTypes.number,
-  left: PropTypes.number,
-  right: PropTypes.number,
-  bottom: PropTypes.number,
-  margin: PropTypes.number,
-  marginVertical: PropTypes.number,
-  marginHorizontal: PropTypes.number,
-  marginTop: PropTypes.number,
-  marginBottom: PropTypes.number,
-  marginLeft: PropTypes.number,
-  marginRight: PropTypes.number,
-  padding: PropTypes.number,
-  paddingVertical: PropTypes.number,
-  paddingHorizontal: PropTypes.number,
-  paddingTop: PropTypes.number,
-  paddingBottom: PropTypes.number,
-  paddingLeft: PropTypes.number,
-  paddingRight: PropTypes.number,
+  width: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.string,
+  ]),
+  height: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.string,
+  ]),
+  top: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.string,
+  ]),
+  left: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.string,
+  ]),
+  right: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.string,
+  ]),
+  bottom: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.string,
+  ]),
+  minWidth: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.string,
+  ]),
+  maxWidth: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.string,
+  ]),
+  minHeight: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.string,
+  ]),
+  maxHeight: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.string,
+  ]),
+  margin: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.string,
+  ]),
+  marginVertical: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.string,
+  ]),
+  marginHorizontal: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.string,
+  ]),
+  marginTop: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.string,
+  ]),
+  marginBottom: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.string,
+  ]),
+  marginLeft: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.string,
+  ]),
+  marginRight: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.string,
+  ]),
+  padding: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.string,
+  ]),
+  paddingVertical: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.string,
+  ]),
+  paddingHorizontal: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.string,
+  ]),
+  paddingTop: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.string,
+  ]),
+  paddingBottom: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.string,
+  ]),
+  paddingLeft: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.string,
+  ]),
+  paddingRight: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.string,
+  ]),
   borderWidth: PropTypes.number,
   borderTopWidth: PropTypes.number,
   borderRightWidth: PropTypes.number,
@@ -79,7 +155,8 @@ const LayoutPropTypes = {
     'flex-start',
     'flex-end',
     'center',
-    'stretch'
+    'stretch',
+    'baseline'
   ]),
 
   // How to align the element in the cross direction
@@ -89,11 +166,28 @@ const LayoutPropTypes = {
     'flex-start',
     'flex-end',
     'center',
-    'stretch'
+    'stretch',
+    'baseline'
+  ]),
+
+  overflow: PropTypes.oneOf([
+    'visible',
+    'hidden',
+    'scroll'
   ]),
 
   // https://developer.mozilla.org/en-US/docs/Web/CSS/flex
   flex: PropTypes.number,
+  flexGrow: PropTypes.number,
+  flexShrink: PropTypes.number,
+  flexBasis: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.string,
+  ]),
+
+  aspectRatio: PropTypes.number,
+
+  zIndex: PropTypes.number,
 };
 
 module.exports = LayoutPropTypes;

--- a/src/propTypes/TextStylePropTypes.js
+++ b/src/propTypes/TextStylePropTypes.js
@@ -22,6 +22,18 @@ const TextStylePropTypes = Object.assign(Object.create(ViewStylePropTypes), {
     ['normal', 'bold',
      '100', '200', '300', '400', '500', '600', '700', '800', '900']
   ),
+  /**
+   * @platform ios
+   */
+  fontVariant: PropTypes.arrayOf(
+    PropTypes.oneOf([
+      'small-caps',
+      'oldstyle-nums',
+      'lining-nums',
+      'tabular-nums',
+      'proportional-nums',
+    ])
+  ),
   textShadowOffset: PropTypes.shape(
     {
       width: PropTypes.number,

--- a/src/propTypes/ViewStylePropTypes.js
+++ b/src/propTypes/ViewStylePropTypes.js
@@ -35,7 +35,6 @@ const ViewStylePropTypes = {
   borderBottomWidth: PropTypes.number,
   borderLeftWidth: PropTypes.number,
   opacity: PropTypes.number,
-  overflow: PropTypes.oneOf(['visible', 'hidden']),
   /**
    * (Android-only) Sets the elevation of a view, using Android's underlying
    * [elevation API](https://developer.android.com/training/material/shadows-clipping.html#Elevation).


### PR DESCRIPTION
This adds style prop types that support percentage values, which were added to RN in 0.42.0. I took the opportunity to update all the prop type files to match the way they look in React Native 0.42. 

This was needed so that we don't get prop type warnings in our tests where we use percentage units.