### PR TITLE
NetInfo.getConnectionInfo()

### DIFF
--- a/src/api/Dimensions.js
+++ b/src/api/Dimensions.js
@@ -1,6 +1,9 @@
 /**
  * https://github.com/facebook/react-native/blob/master/Libraries/Utilities/Dimensions.js
  */
+import invariant from 'invariant';
+import DeviceEventEmitter from '../plugins/DeviceEventEmitter';
+
 const dimensions = {
   // TODO(lmr): find the other dimensions to put in here...
   window: {
@@ -11,13 +14,43 @@ const dimensions = {
   },
 };
 
+const DEVICE_EVENT = 'didUpdateDimensions';
+const _eventHandlers = {
+  change: new Map(),
+};
+
 const Dimensions = {
   set(dims) {
     Object.assign(dimensions, dims);
+    DeviceEventEmitter.emit(DEVICE_EVENT, { dims });
     return true;
   },
   get(dim) {
     return dimensions[dim];
+  },
+  addEventListener(type, handler) {
+    invariant(
+      ['change'].indexOf(type) !== -1,
+      'Trying to subscribe to unknown event: "%s"', type
+    );
+    if (type === 'change') {
+      _eventHandlers[type].set(handler, DeviceEventEmitter.addListener(
+        DEVICE_EVENT,
+        ({ dims }) => handler(dims)
+      ));
+    }
+  },
+  removeEventListener(type, handler) {
+    invariant(
+      ['change'].indexOf(type) !== -1,
+      'Trying to remove listener for unknown event: "%s"', type
+    );
+    const listener = _eventHandlers[type].get(handler)
+    if (!listener) {
+      return;
+    }
+    listener.remove();
+    _eventHandlers[type].delete(handler);
   },
 };
 

--- a/src/api/NetInfo.js
+++ b/src/api/NetInfo.js
@@ -66,6 +66,10 @@ const NetInfo = {
   __setIsConnected(connected) {
     networkInfo = Object.assign({}, networkInfo, { connected });
   },
+
+  getConnectionInfo() {
+    return Promise.resolve({ type: 'wifi', effectiveType: 'unknown' });
+  }
 };
 
 module.exports = NetInfo;

--- a/test/api/NetInfo.js
+++ b/test/api/NetInfo.js
@@ -1,0 +1,12 @@
+import { expect } from 'chai';
+
+import NetInfo from '../../src/api/NetInfo';
+
+
+describe('NetInfo', () => {
+  it('getConnectionInfo', () => {
+    const expectedResult = { type: 'wifi', effectiveType: 'unknown' };
+
+    NetInfo.getConnectionInfo().then(info => expect(info).to.deep.equal(expectedResult));
+  });
+});


### PR DESCRIPTION
Using `wifi` type since it's the one used by iOS simulator as generic one.