### PR TITLE
Add displayNames to all the mocked components

### DIFF
--- a/src/components/ActivityIndicator.js
+++ b/src/components/ActivityIndicator.js
@@ -9,6 +9,7 @@ import View from './View';
 import ColorPropType from '../propTypes/ColorPropType';
 
 const ActivityIndicator = createReactClass({
+  displayName: 'ActivityIndicator',
   propTypes: {
     ...View.propTypes,
     /**

--- a/src/components/ActivityIndicatorIOS.js
+++ b/src/components/ActivityIndicatorIOS.js
@@ -8,6 +8,7 @@ import NativeMethodsMixin from '../mixins/NativeMethodsMixin';
 import View from './View';
 
 const ActivityIndicatorIOS = createReactClass({
+  displayName: 'ActivityIndicatorIOS',
   propTypes: {
     ...View.propTypes,
     /**

--- a/src/components/DrawerLayoutAndroid.js
+++ b/src/components/DrawerLayoutAndroid.js
@@ -12,6 +12,7 @@ import ColorPropType from '../propTypes/ColorPropType';
 const DrawerConsts = UIManager.AndroidDrawerLayout.Constants;
 
 const DrawerLayoutAndroid = createReactClass({
+  displayName: 'DrawerLayoutAndroid',
 
   propTypes: {
     ...View.propTypes,

--- a/src/components/Image.js
+++ b/src/components/Image.js
@@ -11,6 +11,7 @@ import ImageStylePropTypes from '../propTypes/ImageStylePropTypes';
 import ImageResizeMode from '../propTypes/ImageResizeMode';
 
 const Image = createReactClass({
+  displayName: 'Image',
   propTypes: {
     style: styleSheetPropType(ImageStylePropTypes),
     /**

--- a/src/components/ImageBackground.js
+++ b/src/components/ImageBackground.js
@@ -11,6 +11,7 @@ import ImageStylePropTypes from '../propTypes/ImageStylePropTypes';
 import ImageResizeMode from '../propTypes/ImageResizeMode';
 
 const ImageBackground = createReactClass({
+  displayName: 'ImageBackground',
   propTypes: {
     style: styleSheetPropType(ImageStylePropTypes),
     /**

--- a/src/components/ListView.js
+++ b/src/components/ListView.js
@@ -10,6 +10,7 @@ const SCROLLVIEW_REF = 'listviewscroll';
 
 
 const ListView = createReactClass({
+  displayName: 'ListView',
   propTypes: {
     ...ScrollView.propTypes,
 

--- a/src/components/Navigator.js
+++ b/src/components/Navigator.js
@@ -26,6 +26,7 @@ const NavigatorSceneConfigs = {
 };
 
 const Navigator = createReactClass({
+  displayName: 'Navigator',
   propTypes: {
     /**
      * Optional function that allows configuration about scene animations and

--- a/src/components/Picker.js
+++ b/src/components/Picker.js
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import createMockComponent from './createMockComponent';
 
 const Picker = createReactClass({
+  displayName: 'Picker',
   propTypes: {
     children: PropTypes.node
   },

--- a/src/components/ScrollView.js
+++ b/src/components/ScrollView.js
@@ -13,6 +13,7 @@ const SCROLLVIEW = 'ScrollView';
 const INNERVIEW = 'InnerScrollView';
 
 const ScrollView = createReactClass({
+  displayName: 'ScrollView',
   propTypes: {
     ...View.propTypes,
     /**

--- a/src/components/StatusBar.js
+++ b/src/components/StatusBar.js
@@ -14,6 +14,7 @@ let _networkActivityIndicatorVisible = false;
 let _translucent = false;
 
 const StatusBar = createReactClass({
+  displayName: 'StatusBar',
   propTypes: {
     animated: PropTypes.bool,
     barStyle: PropTypes.oneOf(['default', 'light-content']),

--- a/src/components/TabBarIOS.js
+++ b/src/components/TabBarIOS.js
@@ -4,6 +4,7 @@ import createReactClass from 'create-react-class';
 import createMockComponent from './createMockComponent';
 
 const TabBarIOS = createReactClass({
+  displayName: 'TabBarIOS',
   propTypes: {
     children: PropTypes.node
   },

--- a/src/components/Text.js
+++ b/src/components/Text.js
@@ -11,6 +11,7 @@ import NativeMethodsMixin from '../mixins/NativeMethodsMixin';
 const stylePropType = styleSheetPropType(TextStylePropTypes);
 
 const Text = createReactClass({
+  displayName: 'Text',
   propTypes: {
     /**
      * Used to truncate the text with an ellipsis after computing the text

--- a/src/components/TextInput.js
+++ b/src/components/TextInput.js
@@ -8,6 +8,7 @@ import View from './View';
 import Text from './Text';
 
 const TextInput = createReactClass({
+  displayName: 'TextInput',
   propTypes: {
     ...View.propTypes,
     /**

--- a/src/components/TouchableNativeFeedback.js
+++ b/src/components/TouchableNativeFeedback.js
@@ -5,6 +5,7 @@ import createReactClass from 'create-react-class';
 import TouchableWithoutFeedback from './TouchableWithoutFeedback';
 
 const TouchableNativeFeedback = createReactClass({
+  displayName: 'TouchableNativeFeedback',
   propTypes: {
     ...TouchableWithoutFeedback.propTypes,
 

--- a/src/components/TouchableOpacity.js
+++ b/src/components/TouchableOpacity.js
@@ -8,6 +8,7 @@ import createReactClass from 'create-react-class';
 import TouchableWithoutFeedback from './TouchableWithoutFeedback';
 
 const TouchableOpacity = createReactClass({
+  displayName: 'TouchableOpacity',
   propTypes: {
     ...TouchableWithoutFeedback.propTypes,
 

--- a/src/components/TouchableWithoutFeedback.js
+++ b/src/components/TouchableWithoutFeedback.js
@@ -8,6 +8,7 @@ import EdgeInsetsPropType from '../propTypes/EdgeInsetsPropType';
 import View from './View';
 
 const TouchableWithoutFeedback = createReactClass({
+  displayName: 'TouchableWithoutFeedback',
   propTypes: {
     accessible: PropTypes.bool,
     accessibilityComponentType: PropTypes.oneOf(View.AccessibilityComponentType),

--- a/src/components/View.js
+++ b/src/components/View.js
@@ -51,6 +51,7 @@ const statics = {
 };
 
 const View = createReactClass({
+  displayName: 'View',
   propTypes: {
     /**
      * When true, indicates that the view is an accessibility element. By default,

--- a/src/components/WebView.js
+++ b/src/components/WebView.js
@@ -20,6 +20,7 @@ const NavigationType = {
 const JSNavigationScheme = WebViewManager.JSNavigationScheme;
 
 const WebView = createReactClass({
+  displayName: 'WebView',
   propTypes: {
     ...View.propTypes,
     url: PropTypes.string,

--- a/test/mixins/Subscribable.js
+++ b/test/mixins/Subscribable.js
@@ -7,6 +7,7 @@ import createReactClass from 'create-react-class';
 describe('Subscribable.Mixin', () => {
   it('Can mount and unmount with a DeviceEventEmitter subscribed. Does not interupt existing events.', () => {
     const SubscribableClass = createReactClass({
+      displayName: 'SubscribableClass',
       mixins: [Subscribable.Mixin],
       render() {
         return null;


### PR DESCRIPTION
Previously all react-native elements were rendering as 'Unknown', this changes it to render with the actual name of the component.

This fixes enzyme's find, and makes snapshot tests fail when a different react-native element is used from what was expected.