### PR TITLE
Implement setNativeProps in Animated components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ node_modules
 
 /build
 .DS_Store
+
+# IntelliJ IDEA
+/.idea

--- a/src/api/Animated/createAnimatedComponent.js
+++ b/src/api/Animated/createAnimatedComponent.js
@@ -9,6 +9,9 @@ function createAnimatedComponent(Component) {
       children: PropTypes.node,
     }
 
+    setNativeProps() {
+    }
+
     render() {
       return (
         <Component

--- a/src/api/Animated/createAnimatedComponent.js
+++ b/src/api/Animated/createAnimatedComponent.js
@@ -2,8 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 function createAnimatedComponent(Component) {
-  const refName = 'node';
-
   class AnimatedComponent extends React.Component {
     static propTypes = {
       children: PropTypes.node,
@@ -15,7 +13,7 @@ function createAnimatedComponent(Component) {
     render() {
       return (
         <Component
-          ref={refName}
+          ref={() => {}}
         >
           {this.props.children}
         </Component>

--- a/src/components/ART/Path.js
+++ b/src/components/ART/Path.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 var Class = require('art/core/class.js');
 var Path = require('art/core/path.js');
 

--- a/test/components/View.js
+++ b/test/components/View.js
@@ -2,16 +2,15 @@ import React from 'react';
 import View from '../../src/components/View.js';
 import { expect } from 'chai';
 import { mount } from 'enzyme';
-import Animated from '../../src/api/Animated';
 
-describe('Animated.View', () => {
+describe('View', () => {
   let wrapper;
 
   beforeEach(() => {
     wrapper = mount(
-      <Animated.View>
+      <View>
         <View testID="child-view" />
-      </Animated.View>
+      </View>
     );
   });
 


### PR DESCRIPTION
I was trying to use react-native-mock-render to test an app using [React Navigation](https://reactnavigation.org/) and was getting an error due to Animated.View not implementing `setNativeProps`.

Changes in this pull request fix that.