### PR TITLE
Able enzyme to find by component name

### DIFF
--- a/src/components/ActivityIndicator.js
+++ b/src/components/ActivityIndicator.js
@@ -40,7 +40,7 @@ const ActivityIndicator = createReactClass({
   },
   mixins: [NativeMethodsMixin],
   render() {
-    return React.createElement('react-native-mock', null, this.props.children);
+    return React.createElement('ActivityIndicator', null, this.props.children);
   },
 });
 

--- a/src/components/ActivityIndicatorIOS.js
+++ b/src/components/ActivityIndicatorIOS.js
@@ -41,7 +41,7 @@ const ActivityIndicatorIOS = createReactClass({
   mixins: [NativeMethodsMixin],
 
   render() {
-    return React.createElement('react-native-mock', null, this.props.children);
+    return React.createElement('ActivityIndicatorIOS', null, this.props.children);
   },
 });
 

--- a/src/components/DrawerLayoutAndroid.js
+++ b/src/components/DrawerLayoutAndroid.js
@@ -109,7 +109,7 @@ const DrawerLayoutAndroid = createReactClass({
   },
 
   render() {
-    return React.createElement('react-native-mock', null, this.props.children);
+    return React.createElement('DrawerLayoutAndroid', null, this.props.children);
   }
 
 });

--- a/src/components/Image.js
+++ b/src/components/Image.js
@@ -122,7 +122,7 @@ const Image = createReactClass({
     }
   },
   render() {
-    return React.createElement('react-native-mock', null, this.props.children);
+    return React.createElement('Image', null, this.props.children);
   },
 });
 

--- a/src/components/ImageBackground.js
+++ b/src/components/ImageBackground.js
@@ -122,7 +122,7 @@ const ImageBackground = createReactClass({
     }
   },
   render() {
-    return React.createElement('react-native-mock', null, this.props.children);
+    return React.createElement('ImageBackground', null, this.props.children);
   },
 });
 

--- a/src/components/ListView.js
+++ b/src/components/ListView.js
@@ -162,7 +162,7 @@ const ListView = createReactClass({
   },
 
   render() {
-    return React.createElement('react-native-mock', null, this.props.children);
+    return React.createElement('ListView', null, this.props.children);
   },
 });
 

--- a/src/components/Navigator.js
+++ b/src/components/Navigator.js
@@ -101,7 +101,7 @@ const Navigator = createReactClass({
     SceneConfigs: NavigatorSceneConfigs,
   },
   render() {
-    return React.createElement('react-native-mock', null, this.props.children);
+    return React.createElement('Navigator', null, this.props.children);
   }
 });
 

--- a/src/components/Picker.js
+++ b/src/components/Picker.js
@@ -13,7 +13,7 @@ const Picker = createReactClass({
     Item: createMockComponent('Picker.Item')
   },
   render() {
-    return React.createElement('react-native-mock', null, this.props.children);
+    return React.createElement('Picker', null, this.props.children);
   }
 });
 

--- a/src/components/ScrollView.js
+++ b/src/components/ScrollView.js
@@ -318,7 +318,7 @@ const ScrollView = createReactClass({
   },
 
   render() {
-    return React.createElement('react-native-mock', null, this.props.children);
+    return React.createElement('ScrollView', null, this.props.children);
   },
 });
 

--- a/src/components/StatusBar.js
+++ b/src/components/StatusBar.js
@@ -69,7 +69,7 @@ const StatusBar = createReactClass({
   },
 
   render() {
-    return React.createElement('react-native-mock', null, this.props.children);
+    return React.createElement('StatusBar', null, this.props.children);
   }
 });
 

--- a/src/components/TabBarIOS.js
+++ b/src/components/TabBarIOS.js
@@ -12,7 +12,7 @@ const TabBarIOS = createReactClass({
     Item: createMockComponent('TabBarIOS.Item')
   },
   render() {
-    return React.createElement('react-native-mock', null, this.props.children);
+    return React.createElement('TabBarIOS', null, this.props.children);
   }
 });
 

--- a/src/components/Text.js
+++ b/src/components/Text.js
@@ -50,7 +50,7 @@ const Text = createReactClass({
   mixins: [NativeMethodsMixin],
 
   render() {
-    return React.createElement('react-native-mock', null, this.props.children);
+    return React.createElement('Text', null, this.props.children);
   },
 });
 

--- a/src/components/TextInput.js
+++ b/src/components/TextInput.js
@@ -243,7 +243,7 @@ const TextInput = createReactClass({
 
   },
   render() {
-    return React.createElement('react-native-mock', null, this.props.children);
+    return React.createElement('TextInput', null, this.props.children);
   },
 });
 

--- a/src/components/TouchableNativeFeedback.js
+++ b/src/components/TouchableNativeFeedback.js
@@ -18,7 +18,7 @@ const TouchableNativeFeedback = createReactClass({
     Ripple(color, borderless) {}
   },
   render() {
-    return React.createElement('react-native-mock', null, this.props.children);
+    return React.createElement('TouchableNativeFeedback', null, this.props.children);
   }
 });
 

--- a/src/components/TouchableOpacity.js
+++ b/src/components/TouchableOpacity.js
@@ -20,7 +20,7 @@ const TouchableOpacity = createReactClass({
   },
 
   render() {
-    return React.createElement('react-native-mock', null, this.props.children);
+    return React.createElement('TouchableOpacity', null, this.props.children);
   },
 });
 

--- a/src/components/TouchableWithoutFeedback.js
+++ b/src/components/TouchableWithoutFeedback.js
@@ -68,7 +68,7 @@ const TouchableWithoutFeedback = createReactClass({
     children: PropTypes.node
   },
   render() {
-    return React.createElement('react-native-mock', null, this.props.children);
+    return React.createElement('TouchableWithoutFeedback', null, this.props.children);
   },
 });
 

--- a/src/components/View.js
+++ b/src/components/View.js
@@ -284,7 +284,7 @@ const View = createReactClass({
   },
 
   render() {
-    return React.createElement('react-native-mock', null, this.props.children);
+    return React.createElement('View', null, this.props.children);
   },
 });
 

--- a/src/components/WebView.js
+++ b/src/components/WebView.js
@@ -139,7 +139,7 @@ const WebView = createReactClass({
   },
 
   render() {
-    return React.createElement('react-native-mock', null, this.props.children);
+    return React.createElement('WebView', null, this.props.children);
   },
 });
 

--- a/src/components/createMockComponent.js
+++ b/src/components/createMockComponent.js
@@ -9,7 +9,7 @@ function createMockComponent(displayName) {
       children: PropTypes.node
     },
     render() {
-      return React.createElement('react-native-mock', null, this.props.children);
+      return React.createElement(displayName, null, this.props.children);
     },
   });
 }


### PR DESCRIPTION
Currently the render method of every react native component mock has this:

```javascript
return React.createElement('react-native-mock', null, this.props.children);
```

But with this implementation we cannot find components by component name with `enzyme`:
```javascript
wrapper.find('TextInput');
```

I have changed 'react-native-mock' for its component name. For instance, in case of TextInput component:
```javascript
return React.createElement('TextInput', null, this.props.children);
```

With that now I'm able to find by component name.