### PR TITLE
Add I18nManager and dark-content.

### DIFF
--- a/src/Libraries/ReactNative/I18nManager.js
+++ b/src/Libraries/ReactNative/I18nManager.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule I18nManager
  * @flow
  * @format
  */

--- a/src/Libraries/ReactNative/I18nManager.js
+++ b/src/Libraries/ReactNative/I18nManager.js
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @providesModule I18nManager
+ * @flow
+ * @format
+ */
+'use strict';
+
+type I18nManagerStatus = {
+  isRTL: boolean,
+  doLeftAndRightSwapInRTL: boolean,
+  allowRTL: (allowRTL: boolean) => {},
+  forceRTL: (forceRTL: boolean) => {},
+  swapLeftAndRightInRTL: (flipStyles: boolean) => {},
+};
+
+const I18nManager: I18nManagerStatus = {
+  isRTL: false,
+  doLeftAndRightSwapInRTL: true,
+  allowRTL: () => {},
+  forceRTL: () => {},
+  swapLeftAndRightInRTL: () => {},
+};
+
+module.exports = I18nManager;

--- a/src/components/StatusBar.js
+++ b/src/components/StatusBar.js
@@ -17,7 +17,7 @@ const StatusBar = createReactClass({
   displayName: 'StatusBar',
   propTypes: {
     animated: PropTypes.bool,
-    barStyle: PropTypes.oneOf(['default', 'light-content']),
+    barStyle: PropTypes.oneOf(['default', 'light-content', 'dark-content']),
     backgroundColor: ColorPropType,
     hidden: PropTypes.bool,
     networkActivityIndicatorVisible: PropTypes.bool,

--- a/src/react-native.js
+++ b/src/react-native.js
@@ -72,6 +72,7 @@ const ReactNative = {
   Dimensions: require('./api/Dimensions'),
   Easing: require('./api/Animated/Easing'),
   findNodeHandle: require('./api/findNodeHandle'),
+  I18nManager: require('./Libraries/ReactNative/I18nManager'),
   ImagePickerIOS: require('./api/ImagePickerIOS'),
   IntentAndroid: require('./api/IntentAndroid'),
   InteractionManager: require('./api/InteractionManager'),


### PR DESCRIPTION
The I18nManager.js is a copy/paste from the react-native one, which
already had a mock in an `||`, and I just removed the first part of
that expression. (Originally tried just leaving it in, but the
require('NativeModules') would not just return undefined, but
actively throw an error.

https://github.com/facebook/react-native/blob/master/Libraries/ReactNative/I18nManager.js#L21

The dark-content is a valid member of the barStyle enum:

https://facebook.github.io/react-native/docs/statusbar.html#barstyle
