### PR TITLE
Include support for layoutMeasurement in ScrollView

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-mock-render",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "description": "A fork of react-native-mock that renders components",
   "main": "build/react-native.js",
   "scripts": {

--- a/src/components/ScrollView.js
+++ b/src/components/ScrollView.js
@@ -320,6 +320,10 @@ const ScrollView = createReactClass({
 
     this.props.onScroll({
       nativeEvent: {
+        layoutMeasurement: {
+          width: object.width,
+          height: object.height,
+        },
         contentOffset: {
           x: object.x,
           y: object.y,


### PR DESCRIPTION
When testing Scrollview components and expecting a `nativeEvent` to include `layoutMeasurement` properties, those tests would fail.

This PR updates the component to generate a `nativeEvent` that has more realistic properties.