### PR TITLE
add flashScrollIndicators to ScrollView

### DIFF
--- a/src/components/ScrollView.js
+++ b/src/components/ScrollView.js
@@ -331,6 +331,10 @@ const ScrollView = createReactClass({
       },
     });
   },
+  
+  flashScrollIndicators() {
+    // no-op. Only has an effect on the UI
+  }
 
   render() {
     return React.createElement('react-native-mock', null, this.props.children);

--- a/src/components/ScrollView.js
+++ b/src/components/ScrollView.js
@@ -334,7 +334,7 @@ const ScrollView = createReactClass({
   
   flashScrollIndicators() {
     // no-op. Only has an effect on the UI
-  }
+  },
 
   render() {
     return React.createElement('react-native-mock', null, this.props.children);


### PR DESCRIPTION
This method was missing from the `ScrollView`. See [the React Native docs](https://facebook.github.io/react-native/docs/scrollview#flashscrollindicators) for more.