### PR TITLE
Fix Platform.select to return the default if the current OS isn't in the object passed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-mock-render",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "A fork of react-native-mock that renders components",
   "main": "build/react-native.js",
   "scripts": {

--- a/src/plugins/Platform.js
+++ b/src/plugins/Platform.js
@@ -13,7 +13,7 @@ const Platform = {
   },
 
   select(objs) {
-    return objs[Platform.OS];
+    return Platform.OS in objs ? objs[Platform.OS] : objs.default;
   },
 
   /**


### PR DESCRIPTION
Fixes this `Platform.select`in our specs here: https://github.com/expo/react-native-action-sheet/blob/22753e0c0c765651403e6618069ccc8677738f5e/src/ActionSheet/TouchableNativeFeedbackSafe.tsx#L17-L20

This select implementation matches the actual react-native implementation: https://github.com/facebook/react-native/blob/master/Libraries/Utilities/Platform.ios.js#L62-L64