### PR TITLE
Fix ItemSeparatorComponent Type

### DIFF
--- a/src/components/FlatList.js
+++ b/src/components/FlatList.js
@@ -36,7 +36,7 @@ const FlatList = createReactClass({
     * separators.highlight/unhighlight which will update the highlighted prop,
     * but you can also add custom props with separators.updateProps.
     */
-    ItemSeparatorComponent: PropTypes.element,
+    ItemSeparatorComponent: PropTypes.func,
     /**
     * Optional custom style for multi-item rows generated when numColumns > 1.
     */


### PR DESCRIPTION
This PR fixes the ItemSeparatorComponent type from component to function. Despite the fact that react-native documentation states that this is component, it is indeed a function, as evidenced by [their tests](https://github.com/facebook/react-native/blob/aee88b6843cea63d6aa0b5879ad6ef9da4701846/Libraries/Lists/__tests__/SectionList-test.js).