### PR TITLE
Fixed header and footer not rendering in <FlatList />

### DIFF
--- a/src/components/FlatList.js
+++ b/src/components/FlatList.js
@@ -4,6 +4,7 @@ import createReactClass from 'create-react-class';
 import VirtualizedList from './VirtualizedList';
 import ScrollView from './ScrollView';
 import styleSheetPropType from '../propTypes/StyleSheetPropType';
+import View from './View';
 import ViewStylePropTypes from '../propTypes/ViewStylePropTypes';
 
 const stylePropType = styleSheetPropType(ViewStylePropTypes);
@@ -140,23 +141,51 @@ const FlatList = createReactClass({
     return React.cloneElement(child, { key });
   },
 
-  _renderChildren() {
-    return this.props.data.map((item, index) => {
-      const child = this.props.renderItem({
-        item,
-        index,
-        separators: {
-          highlight: () => {},
-          unhighlight: () => {},
-          updateProps: () => {},
-        },
-      });
-      return this._cloneWithKey(child, item, index);
-    });
-  },
-
   render() {
-    return React.createElement('react-native-mock', null, this._renderChildren());
+    const { data, ListHeaderComponent, ListFooterComponent } = this.props;
+    const cells = [];
+
+    if (ListHeaderComponent) {
+      const element = React.isValidElement(ListHeaderComponent) ? ListHeaderComponent : <ListHeaderComponent />;
+      cells.push(
+        <View key="flatlist-header-key">
+          <View testID="flatlist-header">
+            {element}
+          </View>
+        </View>,
+      );
+    }
+
+    if (data) {
+      this.props.data.forEach((item, index) => {
+        const child = this.props.renderItem({
+          item,
+          index,
+          separators: {
+            highlight: () => { },
+            unhighlight: () => { },
+            updateProps: () => { },
+          },
+        });
+
+        if (child) {
+          cells.push(this._cloneWithKey(child, item, index));
+        }
+      });
+    }
+
+    if (ListFooterComponent) {
+      const element = React.isValidElement(ListFooterComponent) ? ListFooterComponent : <ListFooterComponent />;
+      cells.push(
+        <View key="flatlist-footer-key">
+          <View testID="flatlist-footer">
+            {element}
+          </View>
+        </View>,
+      );
+    }
+
+    return React.createElement('react-native-mock', null, cells);
   },
 });
 

--- a/test/components/FlatList.js
+++ b/test/components/FlatList.js
@@ -12,6 +12,38 @@ describe('FlatList', () => {
     { value: 'item-3', key: 'key-3', id: 'id-3' },
   ];
 
+  describe('ListHeaderComponent', () => {
+    context('when passed a ListHeaderComponent', () => {
+      it('renders', () => {
+        wrapper = mount(<FlatList ListHeaderComponent={<View />} />);
+        expect(wrapper.find('View[testID="flatlist-header"]').length).to.eq(1);
+      });
+    });
+
+    context('when not passed a ListHeaderComponent', () => {
+      it('does not render', () => {
+        wrapper = mount(<FlatList />);
+        expect(wrapper.find('View[testID="flatlist-header"]').length).to.eq(0);
+      });
+    });
+  });
+
+  describe('ListFooterComponent', () => {
+    context('when passed a ListFooterComponent', () => {
+      it('renders', () => {
+        wrapper = mount(<FlatList ListFooterComponent={<View />} />);
+        expect(wrapper.find('View[testID="flatlist-footer"]').length).to.eq(1);
+      });
+    });
+
+    context('when not passed a ListFooterComponent', () => {
+      it('does not render', () => {
+        wrapper = mount(<FlatList />);
+        expect(wrapper.find('View[testID="flatlist-footer"]').length).to.eq(0);
+      });
+    });
+  });
+
   it('renders its children', () => {
     wrapper = mount(
       <FlatList


### PR DESCRIPTION
This PR fixes the header and footer props not being rendered in `<FlatList />`, which caused tests to fail