### PR TITLE
Adding clear method for AppState and cleanup ScrollResponder listeners

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-mock-render",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "A fork of react-native-mock that renders components",
   "main": "build/react-native.js",
   "scripts": {

--- a/src/api/AppState.js
+++ b/src/api/AppState.js
@@ -39,6 +39,11 @@ const AppState = {
     _eventHandlers[type].delete(handler);
   },
 
+  clearEventHandlers() {
+    _eventHandlers.change.clear();
+    _eventHandlers.memoryWarning.clear();
+  },
+
   currentState: 'active',
 
   __setAppState(appState) {

--- a/src/mixins/ScrollResponder.js
+++ b/src/mixins/ScrollResponder.js
@@ -441,6 +441,13 @@ const ScrollResponderMixin = {
     this.addListenerOn(DeviceEventEmitter, 'keyboardDidHide', this.scrollResponderKeyboardDidHide);
   },
 
+  componentWillUnmount() {
+    DeviceEventEmitter.removeListener('keyboardWillShow', this.scrollResponderKeyboardWillShow);
+    DeviceEventEmitter.removeListener('keyboardWillHide', this.scrollResponderKeyboardWillHide);
+    DeviceEventEmitter.removeListener('keyboardDidShow', this.scrollResponderKeyboardDidShow);
+    DeviceEventEmitter.removeListener('keyboardDidHide', this.scrollResponderKeyboardDidHide);
+  },
+
   /**
    * Warning, this may be called several times for a single keyboard opening.
    * It's best to store the information in this method and then take any action


### PR DESCRIPTION
This PR adds a `clearEventHandlers` method to the `AppState` api. This allows the handlers to be removed in test scenarios where the `removeEventListener` method is not being called reliably.

Additionally the `ScrollRenderer` will remove its listeners when it unmounts.