### PR TITLE
Update Mock components to render using actual names instead of react-native-mock

### DIFF
--- a/src/components/ActivityIndicator.js
+++ b/src/components/ActivityIndicator.js
@@ -40,7 +40,7 @@ const ActivityIndicator = createReactClass({
   },
   mixins: [NativeMethodsMixin],
   render() {
-    return React.createElement('react-native-mock', null, this.props.children);
+    return React.createElement('ActivityIndicator', this.props, this.props.children);
   },
 });
 

--- a/src/components/ActivityIndicatorIOS.js
+++ b/src/components/ActivityIndicatorIOS.js
@@ -41,7 +41,7 @@ const ActivityIndicatorIOS = createReactClass({
   mixins: [NativeMethodsMixin],
 
   render() {
-    return React.createElement('react-native-mock', null, this.props.children);
+    return React.createElement('ActivityIndicatorIOS', this.props, this.props.children);
   },
 });
 

--- a/src/components/DrawerLayoutAndroid.js
+++ b/src/components/DrawerLayoutAndroid.js
@@ -109,7 +109,7 @@ const DrawerLayoutAndroid = createReactClass({
   },
 
   render() {
-    return React.createElement('react-native-mock', null, this.props.children);
+    return React.createElement('DrawerLayoutAndroid', this.props, this.props.children);
   }
 
 });

--- a/src/components/FlatList.js
+++ b/src/components/FlatList.js
@@ -185,7 +185,7 @@ const FlatList = createReactClass({
       );
     }
 
-    return React.createElement('react-native-mock', null, cells);
+    return React.createElement('FlatList', this.props, cells);
   },
 });
 

--- a/src/components/Image.js
+++ b/src/components/Image.js
@@ -122,7 +122,7 @@ const Image = createReactClass({
     }
   },
   render() {
-    return React.createElement('react-native-mock', null, this.props.children);
+    return React.createElement('Image', this.props, this.props.children);
   },
 });
 

--- a/src/components/ImageBackground.js
+++ b/src/components/ImageBackground.js
@@ -122,7 +122,7 @@ const ImageBackground = createReactClass({
     }
   },
   render() {
-    return React.createElement('react-native-mock', null, this.props.children);
+    return React.createElement('ImageBackground', this.props, this.props.children);
   },
 });
 

--- a/src/components/ListView.js
+++ b/src/components/ListView.js
@@ -162,7 +162,7 @@ const ListView = createReactClass({
   },
 
   render() {
-    return React.createElement('react-native-mock', null, this.props.children);
+    return React.createElement('ListView', this.props, this.props.children);
   },
 });
 

--- a/src/components/Navigator.js
+++ b/src/components/Navigator.js
@@ -101,7 +101,7 @@ const Navigator = createReactClass({
     SceneConfigs: NavigatorSceneConfigs,
   },
   render() {
-    return React.createElement('react-native-mock', null, this.props.children);
+    return React.createElement('Navigator', this.props, this.props.children);
   }
 });
 

--- a/src/components/Picker.js
+++ b/src/components/Picker.js
@@ -13,7 +13,7 @@ const Picker = createReactClass({
     Item: createMockComponent('Picker.Item')
   },
   render() {
-    return React.createElement('react-native-mock', null, this.props.children);
+    return React.createElement('Picker', this.props, this.props.children);
   }
 });
 

--- a/src/components/SafeAreaView.js
+++ b/src/components/SafeAreaView.js
@@ -23,7 +23,7 @@ class SafeAreaView extends React.Component {
   };
 
   render() {
-    return React.createElement('react-native-mock', null, this.props.children);
+    return React.createElement('SafeAreaView', this.props, this.props.children);
   }
 }
 

--- a/src/components/ScrollView.js
+++ b/src/components/ScrollView.js
@@ -337,7 +337,7 @@ const ScrollView = createReactClass({
   },
 
   render() {
-    return React.createElement('react-native-mock', null, this.props.children);
+    return React.createElement('ScrollView', this.props, this.props.children);
   },
 });
 

--- a/src/components/SectionList.js
+++ b/src/components/SectionList.js
@@ -250,7 +250,7 @@ const SectionList = createReactClass({
   },
 
   render() {
-    return React.createElement('react-native-mock', null, this._renderChildren());
+    return React.createElement('SectionList', this.props, this._renderChildren());
   },
 });
 

--- a/src/components/StatusBar.js
+++ b/src/components/StatusBar.js
@@ -69,7 +69,7 @@ const StatusBar = createReactClass({
   },
 
   render() {
-    return React.createElement('react-native-mock', null, this.props.children);
+    return React.createElement('StatusBar', this.props, this.props.children);
   }
 });
 

--- a/src/components/TabBarIOS.js
+++ b/src/components/TabBarIOS.js
@@ -12,7 +12,7 @@ const TabBarIOS = createReactClass({
     Item: createMockComponent('TabBarIOS.Item')
   },
   render() {
-    return React.createElement('react-native-mock', null, this.props.children);
+    return React.createElement('TabBarIOS', this.props, this.props.children);
   }
 });
 

--- a/src/components/Text.js
+++ b/src/components/Text.js
@@ -50,7 +50,7 @@ const Text = createReactClass({
   mixins: [NativeMethodsMixin],
 
   render() {
-    return React.createElement('react-native-mock', null, this.props.children);
+    return React.createElement('Text', this.props, this.props.children);
   },
 });
 

--- a/src/components/TextInput.js
+++ b/src/components/TextInput.js
@@ -243,7 +243,7 @@ const TextInput = createReactClass({
 
   },
   render() {
-    return React.createElement('react-native-mock', null, this.props.children);
+    return React.createElement('TextInput', this.props, this.props.children);
   },
 });
 

--- a/src/components/TouchableNativeFeedback.js
+++ b/src/components/TouchableNativeFeedback.js
@@ -18,7 +18,7 @@ const TouchableNativeFeedback = createReactClass({
     Ripple(color, borderless) {}
   },
   render() {
-    return React.createElement('react-native-mock', null, this.props.children);
+    return React.createElement('TouchableNativeFeedback', this.props, this.props.children);
   }
 });
 

--- a/src/components/TouchableOpacity.js
+++ b/src/components/TouchableOpacity.js
@@ -20,7 +20,7 @@ const TouchableOpacity = createReactClass({
   },
 
   render() {
-    return React.createElement('react-native-mock', null, this.props.children);
+    return React.createElement('TouchableOpacity', this.props, this.props.children);
   },
 });
 

--- a/src/components/TouchableWithoutFeedback.js
+++ b/src/components/TouchableWithoutFeedback.js
@@ -68,7 +68,7 @@ const TouchableWithoutFeedback = createReactClass({
     children: PropTypes.node
   },
   render() {
-    return React.createElement('react-native-mock', null, this.props.children);
+    return React.createElement('TouchableWithoutFeedback', this.props, this.props.children);
   },
 });
 

--- a/src/components/View.js
+++ b/src/components/View.js
@@ -284,7 +284,7 @@ const View = createReactClass({
   },
 
   render() {
-    return React.createElement('react-native-mock', null, this.props.children);
+    return React.createElement('View', this.props, this.props.children);
   },
 });
 

--- a/src/components/VirtualizedList.js
+++ b/src/components/VirtualizedList.js
@@ -275,7 +275,7 @@ const VirtualizedList = createReactClass({
   },
 
   render() {
-    return React.createElement('react-native-mock', null, this._renderChildren());
+    return React.createElement('VirtualizedList', this.props, this._renderChildren());
   },
 });
 

--- a/src/components/VirtualizedSectionList.js
+++ b/src/components/VirtualizedSectionList.js
@@ -130,7 +130,7 @@ const VirtualizedSectionList = createReactClass({
   },
 
   render() {
-    return React.createElement('react-native-mock', null, this._renderChildren());
+    return React.createElement('VirtualizedSectionList', this.props, this._renderChildren());
   },
 });
 

--- a/src/components/WebView.js
+++ b/src/components/WebView.js
@@ -139,7 +139,7 @@ const WebView = createReactClass({
   },
 
   render() {
-    return React.createElement('react-native-mock', null, this.props.children);
+    return React.createElement('WebView', this.props, this.props.children);
   },
 });
 

--- a/src/components/createMockComponent.js
+++ b/src/components/createMockComponent.js
@@ -9,7 +9,7 @@ function createMockComponent(displayName) {
       children: PropTypes.node
     },
     render() {
-      return React.createElement('react-native-mock', null, this.props.children);
+      return React.createElement(displayName, this.props, this.props.children);
     },
   });
 }


### PR DESCRIPTION
This PR updates all of the RN mock components to render using their actual names and props instead of using `react-native-mock`. 