### PR TITLE
Add focus/blur App State events

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-mock-render",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "A fork of react-native-mock that renders components",
   "main": "build/react-native.js",
   "scripts": {

--- a/src/api/AppState.js
+++ b/src/api/AppState.js
@@ -12,7 +12,7 @@ const _eventHandlers = {
 const AppState = {
   addEventListener(type, handler) {
     invariant(
-      ['change', 'memoryWarning'].indexOf(type) !== -1,
+      ['change', 'memoryWarning', 'focus', 'blur'].indexOf(type) !== -1,
       'Trying to subscribe to unknown event: "%s"', type
     );
     if (type === 'change') {


### PR DESCRIPTION
Adds support for `focus`/`blur` events that were added to React Native as part of [this PR](https://github.com/facebook/react-native/pull/25039). 